### PR TITLE
Fixing JavaScript syntax error when message has line break

### DIFF
--- a/src/ToastMagic.php
+++ b/src/ToastMagic.php
@@ -171,7 +171,7 @@ class ToastMagic
 
             // Add a delay for each message
             $script .= 'setTimeout(function() {
-                toastMagic.' . $message['type'] . '("' . addslashes($message['message']) . '", "' . $description . '", ' . (isset($config['closeButton']) && $config['closeButton'] ? 'true' : 'false') . ', "' . ($config['customBtnText'] ?? '') . '", "' . ($config['customBtnLink'] ?? '') . '");
+                toastMagic.' . $message['type'] . '(`' . addslashes($message['message']) . '`, `' . $description . '`, ' . (isset($config['closeButton']) && $config['closeButton'] ? 'true' : 'false') . ', "' . ($config['customBtnText'] ?? '') . '", "' . ($config['customBtnLink'] ?? '') . '");
             }, ' . $delay . ');';
 
             // Increase the delay for the next message (500ms for each)


### PR DESCRIPTION
## Description
Replaced `"` with ` ` ` when building the script to fix JavaScript syntax error because of line break.

## Changes Made
- [x] Bug fixed  

## Screenshots 
<img width="1416" height="132" alt="image" src="https://github.com/user-attachments/assets/f9c1e4b8-949b-4c61-9df2-75f3fba2131f" />

## Checklist
- [x] My code follows the project coding style.
- [x] I have tested my changes and verified they work as expected.
- [ ] I have added necessary documentation (if applicable).